### PR TITLE
impl: Implement CrawledPage entity with MongoDB TTL and repository test

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -8,6 +8,10 @@ plugins {
 dependencies {
     implementation(project(":common"))
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
+    implementation("org.slf4j:slf4j-api:2.0.17")
+    implementation("ch.qos.logback:logback-classic:1.5.18")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("de.flapdoodle.embed:de.flapdoodle.embed.mongo:4.20.1")
 }
 
 tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar") {

--- a/data/src/main/kotlin/com/jammking/webprobe/data/config/MongoConfig.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/config/MongoConfig.kt
@@ -1,0 +1,22 @@
+package com.jammking.webprobe.data.config
+
+import com.jammking.webprobe.data.entity.CrawledPage
+import jakarta.annotation.PostConstruct
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.Sort
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.index.Index
+
+@Configuration
+class MongoConfig(
+    private val mongoTemplate: MongoTemplate
+) {
+    @PostConstruct
+    fun setupIndexes() {
+        val ttlIndex = Index()
+            .on("expiredAt", Sort.Direction.ASC)
+            .expire(0)
+
+        mongoTemplate.indexOps(CrawledPage::class.java).ensureIndex(ttlIndex)
+    }
+}

--- a/data/src/main/kotlin/com/jammking/webprobe/data/entity/CrawledPage.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/entity/CrawledPage.kt
@@ -1,0 +1,18 @@
+package com.jammking.webprobe.data.entity
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.Duration
+import java.time.Instant
+
+@Document(collection = "crawled_pages")
+data class CrawledPage(
+    @Id
+    val url: String,
+    val title: String,
+    val html: String,
+    val text: String,
+    val summary: String?,
+    val createdAt: Instant = Instant.now(),
+    val expiredAt: Instant = createdAt.plus(Duration.ofDays(30))
+)

--- a/data/src/main/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepository.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepository.kt
@@ -1,0 +1,8 @@
+package com.jammking.webprobe.data.repository
+
+import com.jammking.webprobe.data.entity.CrawledPage
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface CrawledPageRepository: MongoRepository<CrawledPage, String> {
+    fun findByUrl(url: String): CrawledPage?
+}

--- a/data/src/test/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepositoryTest.kt
+++ b/data/src/test/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepositoryTest.kt
@@ -1,0 +1,43 @@
+package com.jammking.webprobe.data.repository
+
+import com.jammking.webprobe.data.entity.CrawledPage
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import java.time.Duration
+import java.time.Instant
+
+@DataMongoTest
+class CrawledPageRepositoryTest {
+
+    @Autowired
+    lateinit var repository: CrawledPageRepository
+
+    private val log = LoggerFactory.getLogger(this::class.java)
+
+    @Test
+    fun `should save and retrieve a crawled page by url`() {
+        val url = "https://example.com"
+        val page = CrawledPage(
+            url = url,
+            title = "Example Page",
+            html = "<html><body>Hello</body></html>",
+            text = "Hello",
+            summary = "Short summary",
+            createdAt = Instant.now(),
+            expiredAt = Instant.now().plus(Duration.ofDays(30))
+        )
+
+        log.info("Saving test CrawledPage for URL: $url")
+        repository.save(page)
+
+        val found = repository.findByUrl(url)
+
+        log.info("Fetched page from DB: $found")
+
+        assertThat(found).isNotNull
+        assertThat(found!!.title).isEqualTo("Example Page")
+    }
+}


### PR DESCRIPTION
- Implemented CrawledPage entity with url as the MongoDB document ID
- Configured TTL index on expiredAt field via MongoConfig
- Implemented CrawledPageRepository with a method to find by URL
- Added repoistory unit test