### PR TITLE
refactor: rename CrawledPage to Page to resolve cross-module class co…

### DIFF
--- a/data/src/main/kotlin/com/jammking/webprobe/data/entity/Page.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/entity/Page.kt
@@ -5,14 +5,13 @@ import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.Instant
 
-@Document(collection = "crawled_pages")
-data class CrawledPage(
+@Document(collection = "pages")
+data class Page(
     @Id
     val url: String,
     val title: String,
     val html: String,
     val text: String,
-    val summary: String?,
     @Indexed(expireAfterSeconds = 60 * 60 * 24 * 30)
     val createdAt: Instant = Instant.now(),
 )

--- a/data/src/main/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepository.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepository.kt
@@ -1,8 +1,0 @@
-package com.jammking.webprobe.data.repository
-
-import com.jammking.webprobe.data.entity.CrawledPage
-import org.springframework.data.mongodb.repository.MongoRepository
-
-interface CrawledPageRepository: MongoRepository<CrawledPage, String> {
-    fun findByUrl(url: String): CrawledPage?
-}

--- a/data/src/main/kotlin/com/jammking/webprobe/data/repository/PageRepository.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/repository/PageRepository.kt
@@ -1,0 +1,8 @@
+package com.jammking.webprobe.data.repository
+
+import com.jammking.webprobe.data.entity.Page
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface PageRepository: MongoRepository<Page, String> {
+    fun findByUrl(url: String): Page?
+}

--- a/data/src/test/kotlin/com/jammking/webprobe/data/repository/PageRepositoryTest.kt
+++ b/data/src/test/kotlin/com/jammking/webprobe/data/repository/PageRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.jammking.webprobe.data.repository
 
 import com.jammking.webprobe.data.DataTestApplication
-import com.jammking.webprobe.data.entity.CrawledPage
+import com.jammking.webprobe.data.entity.Page
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
@@ -12,22 +12,21 @@ import java.time.Instant
 
 @ActiveProfiles("test")
 @SpringBootTest(classes = [DataTestApplication::class])
-class CrawledPageRepositoryTest {
+class PageRepositoryTest {
 
     @Autowired
-    lateinit var repository: CrawledPageRepository
+    lateinit var repository: PageRepository
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
     @Test
     fun `should save and retrieve a crawled page by url`() {
         val url = "https://example.com"
-        val page = CrawledPage(
+        val page = Page(
             url = url,
             title = "Example Page",
             html = "<html><body>Hello</body></html>",
             text = "Hello",
-            summary = "Short summary",
             createdAt = Instant.now(),
         )
 


### PR DESCRIPTION
…nflict

- Renamed CrawledPage to Page in the data module to avoid name collision with crawler module.
- Updated PageRepository and PageRepositoryTest accordingly.
- Ensured consistent usage across repository and test classes.