### PR TITLE
refactor: rename Page back to CrawledPage for consistency

### DIFF
--- a/data/src/main/kotlin/com/jammking/webprobe/data/entity/CrawledPage.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/entity/CrawledPage.kt
@@ -5,8 +5,8 @@ import org.springframework.data.mongodb.core.index.Indexed
 import org.springframework.data.mongodb.core.mapping.Document
 import java.time.Instant
 
-@Document(collection = "pages")
-data class Page(
+@Document(collection = "crawled_pages")
+data class CrawledPage(
     @Id
     val url: String,
     val title: String,

--- a/data/src/main/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepository.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepository.kt
@@ -1,0 +1,8 @@
+package com.jammking.webprobe.data.repository
+
+import com.jammking.webprobe.data.entity.CrawledPage
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface CrawledPageRepository: MongoRepository<CrawledPage, String> {
+    fun findByUrl(url: String): CrawledPage?
+}

--- a/data/src/main/kotlin/com/jammking/webprobe/data/repository/PageRepository.kt
+++ b/data/src/main/kotlin/com/jammking/webprobe/data/repository/PageRepository.kt
@@ -1,8 +1,0 @@
-package com.jammking.webprobe.data.repository
-
-import com.jammking.webprobe.data.entity.Page
-import org.springframework.data.mongodb.repository.MongoRepository
-
-interface PageRepository: MongoRepository<Page, String> {
-    fun findByUrl(url: String): Page?
-}

--- a/data/src/test/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepositoryTest.kt
+++ b/data/src/test/kotlin/com/jammking/webprobe/data/repository/CrawledPageRepositoryTest.kt
@@ -1,7 +1,7 @@
 package com.jammking.webprobe.data.repository
 
 import com.jammking.webprobe.data.DataTestApplication
-import com.jammking.webprobe.data.entity.Page
+import com.jammking.webprobe.data.entity.CrawledPage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
@@ -12,17 +12,17 @@ import java.time.Instant
 
 @ActiveProfiles("test")
 @SpringBootTest(classes = [DataTestApplication::class])
-class PageRepositoryTest {
+class CrawledPageRepositoryTest {
 
     @Autowired
-    lateinit var repository: PageRepository
+    lateinit var repository: CrawledPageRepository
 
     private val log = LoggerFactory.getLogger(this::class.java)
 
     @Test
     fun `should save and retrieve a crawled page by url`() {
         val url = "https://example.com"
-        val page = Page(
+        val crawledPage = CrawledPage(
             url = url,
             title = "Example Page",
             html = "<html><body>Hello</body></html>",
@@ -31,7 +31,7 @@ class PageRepositoryTest {
         )
 
         log.info("Saving test CrawledPage for URL: $url")
-        repository.save(page)
+        repository.save(crawledPage)
 
         val found = repository.findByUrl(url)
 


### PR DESCRIPTION
Reverted previous renaming of CrawledPage to Page in the data module. Since CrawledPage should be defined and managed centrally in the data module, the name was restored for clarity and consistency across modules.

Renamed:
- Page -> CrawledPage
- PageRepository -> CrawledPageRepository
- PageRepositoryTest -> CrawledPageRepositoryTest