### PR TITLE
feat: implement search controller and global exception handler

### DIFF
--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -7,8 +7,9 @@ plugins {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
-    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.7.3")
 
     implementation(project(":common"))
     implementation(project(":crawler"))

--- a/application/src/main/kotlin/com/jammking/webprobe/application/controller/CrawlerController.kt
+++ b/application/src/main/kotlin/com/jammking/webprobe/application/controller/CrawlerController.kt
@@ -1,0 +1,37 @@
+package com.jammking.webprobe.application.controller
+
+import com.jammking.webprobe.application.exception.InvalidSearchRequestException
+import com.jammking.webprobe.crawler.model.CrawlerResult
+import com.jammking.webprobe.crawler.model.SearchRequest
+import com.jammking.webprobe.crawler.service.Crawler
+import kotlinx.coroutines.reactor.mono
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/search")
+class CrawlerController(
+    private val crawler: Crawler
+) {
+
+    @PostMapping
+    fun search(@RequestBody request: SearchRequest): Mono<ResponseEntity<CrawlerResult>> = mono {
+        validateRequest(request)
+        val result = crawler.crawl(request)
+        ResponseEntity.ok(result)
+    }
+
+    private fun validateRequest(request: SearchRequest) {
+        if(request.keyword.isBlank()) {
+            throw InvalidSearchRequestException("keyword must not be blank")
+        }
+
+        if(request.userId == null && request.fresh) {
+            throw InvalidSearchRequestException("fresh=true is only allowed when userId id provided")
+        }
+    }
+}

--- a/application/src/main/kotlin/com/jammking/webprobe/application/exception/GlobalExceptionHandler.kt
+++ b/application/src/main/kotlin/com/jammking/webprobe/application/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,22 @@
+package com.jammking.webprobe.application.exception
+
+import com.jammking.webprobe.common.exception.WebProbeException
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(WebProbeException::class)
+    fun handleWebProbeException(e: WebProbeException): ResponseEntity<String> {
+        return when(e) {
+            is InvalidSearchRequestException -> ResponseEntity.badRequest().body(e.message)
+            else -> ResponseEntity.internalServerError().body("Internal error: ${e.message}")
+        }
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnknown(e: Exception): ResponseEntity<String> =
+        ResponseEntity.internalServerError().body("Unexpected error occurred.")
+}

--- a/application/src/main/kotlin/com/jammking/webprobe/application/exception/InvalidSearchRequestException.kt
+++ b/application/src/main/kotlin/com/jammking/webprobe/application/exception/InvalidSearchRequestException.kt
@@ -1,0 +1,7 @@
+package com.jammking.webprobe.application.exception
+
+import com.jammking.webprobe.common.exception.WebProbeException
+
+class InvalidSearchRequestException(
+    message: String
+): WebProbeException(message)


### PR DESCRIPTION
- Add CrawlerController to handl POST /api/search requests
  - Validate SearchRequest (keyword must not be blank, fresh=true requires userId)
  - Delegates crawling to Crawler and returns CrawlerResult
- Add GlobalExceptionHandler to catch WebProbeException
  - Returns 400 for InvalidSearchRequestException
  - Returns 500 for other unhandled Exception