### PR TITLE
feat: add InvalidSearchRequestException for shared request validation

### DIFF
--- a/common/src/main/kotlin/com/jammking/webprobe/common/exception/InvalidSearchRequestException.kt
+++ b/common/src/main/kotlin/com/jammking/webprobe/common/exception/InvalidSearchRequestException.kt
@@ -1,0 +1,7 @@
+package com.jammking.webprobe.common.exception
+
+import com.jammking.webprobe.common.exception.WebProbeException
+
+class InvalidSearchRequestException(
+    message: String
+): WebProbeException(message)


### PR DESCRIPTION
- Introduce InvalidSearchRequestException in common module.
- Extends WebProbeException for consistent domain-specific error handling.
- Allows both application and crawler modules to use the same validation exception.