### PR TITLE
test: add WebProbeIntegrationTestApp and SearchApiIntegrationTest

### DIFF
--- a/test-integration/build.gradle.kts
+++ b/test-integration/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
     testImplementation("org.mockito:mockito-core:5.13.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }
 
 tasks.bootJar { enabled = false }

--- a/test-integration/build.gradle.kts
+++ b/test-integration/build.gradle.kts
@@ -6,10 +6,12 @@ plugins {
 }
 
 dependencies {
+    implementation(project(":application"))
     implementation(project(":crawler"))
     implementation(project(":data"))
     implementation(project(":common"))
 
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 
@@ -17,6 +19,9 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.4.0")
+    testImplementation("org.mockito:mockito-core:5.13.0")
 }
 
 tasks.bootJar { enabled = false }

--- a/test-integration/src/test/kotlin/com/jammking/webprobe/CrawlerDataTestApplication.kt
+++ b/test-integration/src/test/kotlin/com/jammking/webprobe/CrawlerDataTestApplication.kt
@@ -1,14 +1,9 @@
 package com.jammking.webprobe
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.runApplication
 
 @SpringBootApplication(scanBasePackages = [
     "com.jammking.webprobe.crawler",
     "com.jammking.webprobe.data"
 ])
 class CrawlerDataTestApplication
-
-fun main(args: Array<String>) {
-    runApplication<CrawlerDataTestApplication>(*args)
-}

--- a/test-integration/src/test/kotlin/com/jammking/webprobe/WebProbeIntegrationTestApp.kt
+++ b/test-integration/src/test/kotlin/com/jammking/webprobe/WebProbeIntegrationTestApp.kt
@@ -1,0 +1,13 @@
+package com.jammking.webprobe
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication(
+    scanBasePackages = [
+        "com.jammking.webprobe.application",
+        "com.jammking.webprobe.crawler",
+        "com.jammking.webprobe.data",
+        "com.jammking.webprobe.common"
+    ]
+)
+class WebProbeIntegrationTestApp

--- a/test-integration/src/test/kotlin/com/jammking/webprobe/application/SearchApiIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jammking/webprobe/application/SearchApiIntegrationTest.kt
@@ -1,0 +1,84 @@
+package com.jammking.webprobe.application
+
+import com.jammking.webprobe.WebProbeIntegrationTestApp
+import com.jammking.webprobe.crawler.adapter.robots.RobotsTxtEvaluator
+import com.jammking.webprobe.crawler.model.SearchEngine
+import com.jammking.webprobe.crawler.port.UrlFetcher
+import com.jammking.webprobe.crawler.service.resolver.UrlFetcherResolver
+import com.jammking.webprobe.data.entity.CrawledPage
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.reactive.server.WebTestClient
+
+@Tag("integration")
+@ActiveProfiles("integration")
+@SpringBootTest(
+    classes = [WebProbeIntegrationTestApp::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@AutoConfigureWebTestClient
+class SearchApiIntegrationTest(
+    @Autowired private val webTestClient: WebTestClient
+) {
+    @MockBean
+    lateinit var urlFetcherResolver: UrlFetcherResolver
+    @MockBean
+    lateinit var robotsTxtEvaluator: RobotsTxtEvaluator
+
+    @Test
+    fun `POST search returns pages end-to-end`() = runTest {
+        whenever(robotsTxtEvaluator.isAllowed(any(), any(), any())).thenReturn(true)
+
+        val searchHtml = """
+            <html>
+                <a class="link_cont" href="https://site.test/p1">1</a>
+                <a class="link_cont" href="https://site.test/p2">2</a>
+            </html>
+        """.trimIndent()
+
+        val searchPageFetcher = mock<UrlFetcher> {
+            onBlocking { fetch(argThat { url -> url.startsWith("https://www.tistory.com/search") }) } doAnswer {
+                val url = it.getArgument<String>(0)
+                CrawledPage(url, "search", searchHtml, "search")
+            }
+        }
+        val contentFetcher = mock<UrlFetcher> {
+            onBlocking { fetch(eq("https://site.test/p1")) } doReturn CrawledPage("https://site.test/p1", "T1", "<html>1</html>", "Text1")
+            onBlocking { fetch(eq("https://site.test/p2")) } doReturn CrawledPage("https://site.test/p2", "T2", "<html>2</html>", "Text2")
+        }
+
+        whenever(urlFetcherResolver.resolve(any()))
+            .thenAnswer { inv ->
+                val url = inv.getArgument<String>(0)
+                if(url.contains("tistory.com/search")) searchPageFetcher
+                else if(url.startsWith("https://site.test/")) contentFetcher
+                else throw IllegalArgumentException("unexpected url: $url")
+            }
+
+        val body = mapOf(
+            "keyword" to "포항 식당 리뷰",
+            "engines" to listOf(SearchEngine.TISTORY),
+            "maxResults" to 2,
+            "userId" to "u1",
+            "fresh" to true
+        )
+
+        webTestClient.post().uri("/api/search")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .exchange()
+            .expectStatus().isOk
+            .expectBody()
+            .jsonPath("$.pages.length()").isEqualTo(2)
+            .jsonPath("$.stats.successCount").isEqualTo(2)
+            .jsonPath("$.errors").isMap
+    }
+}

--- a/test-integration/src/test/kotlin/com/jammking/webprobe/application/SearchApiIntegrationTest.kt
+++ b/test-integration/src/test/kotlin/com/jammking/webprobe/application/SearchApiIntegrationTest.kt
@@ -6,7 +6,11 @@ import com.jammking.webprobe.crawler.model.SearchEngine
 import com.jammking.webprobe.crawler.port.UrlFetcher
 import com.jammking.webprobe.crawler.service.resolver.UrlFetcherResolver
 import com.jammking.webprobe.data.entity.CrawledPage
+import com.jammking.webprobe.data.service.CrawledPageStorage
+import com.jammking.webprobe.data.service.UserSeenStorage
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.*
@@ -26,12 +30,26 @@ import org.springframework.test.web.reactive.server.WebTestClient
 )
 @AutoConfigureWebTestClient
 class SearchApiIntegrationTest(
-    @Autowired private val webTestClient: WebTestClient
+    @Autowired private val webTestClient: WebTestClient,
+    @Autowired private val crawledPageStorage: CrawledPageStorage,
+    @Autowired private val userSeenStorage: UserSeenStorage
 ) {
     @MockBean
     lateinit var urlFetcherResolver: UrlFetcherResolver
     @MockBean
     lateinit var robotsTxtEvaluator: RobotsTxtEvaluator
+
+    @BeforeEach
+    fun setup() {
+        crawledPageStorage.deleteAll()
+        userSeenStorage.deleteAll()
+    }
+
+    @AfterEach
+    fun cleanup() {
+        crawledPageStorage.deleteAll()
+        userSeenStorage.deleteAll()
+    }
 
     @Test
     fun `POST search returns pages end-to-end`() = runTest {

--- a/test-integration/src/test/kotlin/com/jammking/webprobe/crawler/adapter/PlaywrightUrlFetcherTest.kt
+++ b/test-integration/src/test/kotlin/com/jammking/webprobe/crawler/adapter/PlaywrightUrlFetcherTest.kt
@@ -3,8 +3,14 @@ package com.jammking.webprobe.crawler.adapter
 import com.jammking.webprobe.CrawlerDataTestApplication
 import com.jammking.webprobe.crawler.adapter.fetcher.PlaywrightUrlFetcher
 import com.jammking.webprobe.data.entity.CrawledPage
+import com.jammking.webprobe.data.service.CrawledPageStorage
+import com.jammking.webprobe.data.service.UserSeenStorage
 import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -14,23 +20,64 @@ import org.springframework.test.context.ActiveProfiles
 @Tag("integration")
 @ActiveProfiles("integration")
 @SpringBootTest(classes = [CrawlerDataTestApplication::class])
-class PlaywrightUrlFetcherTest {
+class PlaywrightUrlFetcherTest(
+    @Autowired private val fetcher: PlaywrightUrlFetcher,
+    @Autowired private val crawledPageStorage: CrawledPageStorage,
+    @Autowired private val userSeenStorage: UserSeenStorage
+) {
 
-    @Autowired
-    lateinit var fetcher: PlaywrightUrlFetcher
+    private lateinit var server: MockWebServer
+
+    @BeforeEach
+    fun setup() {
+        server = MockWebServer()
+        crawledPageStorage.deleteAll()
+        userSeenStorage.deleteAll()
+    }
+
+    @AfterEach
+    fun cleanup() {
+        server.shutdown()
+        crawledPageStorage.deleteAll()
+        userSeenStorage.deleteAll()
+    }
 
     @Test
-    fun shouldFetchFromPage(): Unit = runBlocking {
+    fun `should fetch and render html with javascript via Playwright`(): Unit = runBlocking {
         // given
-        val url = "https://blog.naver.com/PostView.nhn?blogId=biinii_ary&logNo=223549318498&redirect=Dlog&widgetTypeCall=true"
+        val html = """
+            <!doctype html>
+            <html>
+                <head>
+                    <meta charset="utf-8">
+                    <title>Title</title>
+                </head>
+                <body>
+                    <h1 id="greet">Hello WebProbe</h1>
+                    <p>This is for text extraction</p>
+                    <script>
+                        document.title = "rendering check";
+                    </script>
+                </body>
+            </html>
+        """.trimIndent()
+
+        server.enqueue(
+            MockResponse()
+                .addHeader("Content-Type", "text/html; charset=utf-8")
+                .setBody(html)
+        )
+        server.start()
+        val url = server.url("/test").toString()
 
         // when
         val result: CrawledPage = fetcher.fetch(url)
 
         // then
         assertThat(result.url).isEqualTo(url)
-        assertThat(result.title).isEqualTo("포항 맛집 모음 포항 찐맛집 8곳 총정리 내돈내먹 포항여행맛집코스 : 네이버 블로그")
+        assertThat(result.title).isEqualTo("rendering check")
         assertThat(result.html).contains("<html").contains("</html>")
-        assertThat(result.text).isNotBlank()
+        assertThat(result.text).isNotBlank
+        assertThat(result.text).contains("Hello WebProbe")
     }
 }

--- a/test-integration/src/test/kotlin/com/jammking/webprobe/crawler/service/SearchDrivenCrawlerTest.kt
+++ b/test-integration/src/test/kotlin/com/jammking/webprobe/crawler/service/SearchDrivenCrawlerTest.kt
@@ -3,9 +3,6 @@ package com.jammking.webprobe.crawler.service
 import com.jammking.webprobe.CrawlerDataTestApplication
 import com.jammking.webprobe.crawler.model.SearchEngine
 import com.jammking.webprobe.crawler.model.SearchRequest
-import com.jammking.webprobe.data.entity.CrawledPage
-import com.jammking.webprobe.data.service.CrawledPageStorage
-import com.jammking.webprobe.data.service.UserSeenStorage
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Tag

--- a/test-integration/src/test/resources/application-integration.yml
+++ b/test-integration/src/test/resources/application-integration.yml
@@ -2,3 +2,4 @@ spring:
   data:
     mongodb:
       uri: mongodb://localhost:27017/webprobe-test
+      a  uto-index-creation: true


### PR DESCRIPTION
- Implement WebProbeIntegrationTestApp to bootstrap crawler and data modules for integration tests.
- Add SearchApiIntegrationTest to verify end-to-end search API behavior.
- Enable spring.data.mongod.auto-index-creation in application-integration.yml to ensure compound and TTL indexes are created automatically during tests.